### PR TITLE
fix: changed "Twitter" to "𝕏 (Twitter)" in README.md description section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Tusk is [indicated by Evernote](https://help.evernote.com/hc/en-us/articles/2083
 
 You can now support the development process through [GitHub Sponsors](https://github.com/sponsors/klaussinani).
 
-Come over to [Gitter](https://gitter.im/klaussinani/tusk) or [Twitter](https://twitter.com/klaussinani) to share your thoughts on the project.
+Come over to [Gitter](https://gitter.im/klaussinani/tusk) or [𝕏 (Twitter)](https://twitter.com/klaussinani) to share your thoughts on the project.
 
 Visit the [contributing guidelines](https://github.com/klaussinani/tusk/blob/master/contributing.md#translating-documentation) to learn more on how to translate this document into more languages.
 

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Tusk is [indicated by Evernote](https://help.evernote.com/hc/en-us/articles/2083
 
 You can now support the development process through [GitHub Sponsors](https://github.com/sponsors/klaussinani).
 
-Come over to [Gitter](https://gitter.im/klaussinani/tusk) or [𝕏 (Twitter)](https://twitter.com/klaussinani) to share your thoughts on the project.
+Come over to [Gitter](https://gitter.im/klaussinani/tusk) or [𝕏 (Twitter)](https://x.com/klaussinani) to share your thoughts on the project.
 
 Visit the [contributing guidelines](https://github.com/klaussinani/tusk/blob/master/contributing.md#translating-documentation) to learn more on how to translate this document into more languages.
 


### PR DESCRIPTION
in README.md description changed the name of Twitter to it's new name 𝕏

<!--

Thank you for taking the time to contribute to Tusk! ✨🎉

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klaussinani/tusk/blob/master/contributing.md).

We are always excited about pull requests!
If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage!

Thank you so much again for all of your time invested in the project!

-->
This fixes https://github.com/klaudiosinani/tusk/issues/384
